### PR TITLE
Add support for installing dependencies from Pipfile or requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ specified this in your stack config files.
 
 ## Usage
 
-Here are two quick examples for some common workflows. Both workflows assume a
+Here are three quick examples for some common workflows. Workflows assume a
 Sceptre structure like so:
 ```none
 .
@@ -118,7 +118,7 @@ jobs:
 ```yaml
 # Function: Run pre-commit checks and deploy 'dev' stack group if checks pass
 # Trigger: Push/Merge to all branches, but deployment reserved to 'main' branch
-# Plugins: Install from a Pipfile using Pipenv (or requirements.txt using pip)
+# Plugins: Install from a Pipfile using the specified version of Pipenv 
 name: 'Sceptre Github CI Action'
 on: push
 jobs:
@@ -150,8 +150,11 @@ jobs:
         with:
           sceptre_version: '2.5.0'
           sceptre_pipfile: './Pipfile'
+          # Omit the Pipenv version to use the latest release
+          sceptre_pipenv_version: '2021.5.29'
+          # Or rely on a requirements file instead of Pipenv/Pipfile
           # sceptre_requirements: './requirements.txt'
-          sceptre_subcommand: 'launch --yes dev'
+          sceptre_subcommand: 'launch -y dev'
 ```
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ jobs:
       - name: 'Sceptre launch'
         uses: Sceptre/github-ci-action@master
         with:
-          sceptre_version: '2.5.0'
+          # Store the sceptre version in a Pipfile
           sceptre_pipfile: './Pipfile'
           # Omit the Pipenv version to use the latest release
           sceptre_pipenv_version: '2021.5.29'
-          # Or rely on a requirements file instead of Pipenv/Pipfile
+          # Or rely on a requirements file instead of a Pipfile
           # sceptre_requirements: './requirements.txt'
           sceptre_subcommand: 'launch -y dev'
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: "List of packages (and optionally, versions) to be passed to 'pip install'"
     required: false
     default: ""
+  sceptre_requirements:
+    description: "File path to a Pip requirements file (relative to repository root)"
+    required: false
+    default: ""
+  sceptre_pipfile:
+    description: "File path to a Pipenv Pipfile (relative to repository root)"
+    required: false
+    default: ""
 runs:
     using: "docker"
     image: "./Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "File path to a Pipenv Pipfile (relative to repository root)"
     required: false
     default: ""
+  sceptre_pipenv_version:
+    description: "Version of Pipenv to install"
+    required: false
+    default: ""
 runs:
     using: "docker"
     image: "./Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   sceptre_version:
     description: "Version of Sceptre to install"
     required: false
-    default: "2.5.0"
+    default: ""
   sceptre_directory:
     description: "Directory to execute Sceptre commands from"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,11 +61,6 @@ function parseInputs {
     exit 1
   fi
 
-  if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" && "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
-    echo "WARNING: Detected Pipfile and requirements file"
-    echo "-------  Consider only specifying Python dependencies in one or the other"
-  fi
-
   if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]] \
      && [[   "${INPUT_SCEPTRE_REQUIREMENTS}" != "" \
           || "${INPUT_SCEPTRE_PLUGINS}" != "" \
@@ -107,6 +102,8 @@ function installDeps {
     fi
     echo "Installing Python Pipfile"
     (cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install)
+    sceptreCommandPrefix="pipenv run $sceptreCommandPrefix"
+    return 0
   fi
 
   if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
@@ -128,20 +125,21 @@ function installDeps {
     echo "Installing Sceptre version $sceptreVer"
     pip install --no-input sceptre==$sceptreVer
   fi
+
 }
 
 
 function main {
+
+  sceptreCommandPrefix="sceptre"
+
   parseInputs
   installDeps
 
   cd ${GITHUB_WORKSPACE}/${sceptreDir}
 
-  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
-    pipenv run sceptre $sceptreSubcommand
-  else
-    sceptre $sceptreSubcommand
-  fi
+  $sceptreCommandPrefix $sceptreSubcommand
+  
 }
 
 main "${*}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,22 +5,26 @@ function parseInputs {
   if [[ "${INPUT_SCEPTRE_SUBCOMMAND}" != "" ]]; then
     sceptreSubcommand=${INPUT_SCEPTRE_SUBCOMMAND}
   else
-    echo "Input sceptre_subcommand cannot be empty!"
+    echo "ERROR: Input sceptre_subcommand cannot be empty!"
     exit 1
   fi
 
   # Optional inputs
-  sceptreVer='2.5.0'
   if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
     if [[ "${INPUT_SCEPTRE_VERSION}" =~ ^2[.][0-9][.][0-9]$ ]]; then
       sceptreVer=${INPUT_SCEPTRE_VERSION}
     else
-      echo "Unsupported sceptre version"
+      echo "ERROR: Unsupported sceptre version"
       exit 1
     fi
   else
-    echo "Input sceptre_version cannot be empty!"
-    exit 1
+    if [[ "${INPUT_SCEPTRE_PIPFILE}" == "" && "${INPUT_SCEPTRE_REQUIREMENTS}" == "" ]]; then
+      echo "ERROR: Input sceptre_version cannot be empty!"
+      exit 1
+    else
+      echo "WARNING: Sceptre version not specified, so it's assumed that it"
+      echo "-------  is specified in the Pipfile or requirements file."
+    fi
   fi
 
   sceptreDir="."
@@ -62,36 +66,48 @@ function parseInputs {
     echo "-------  Consider only specifying Python dependencies in one or the other"
   fi
 
+  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]] \
+     && [[   "${INPUT_SCEPTRE_REQUIREMENTS}" != "" \
+          || "${INPUT_SCEPTRE_PLUGINS}" != "" \
+          || "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" \
+          || "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
+        echo "WARNING: Detected Pipfile and at least one other method for specifying"
+        echo "-------  dependencies/versions. Only the Pipfile will be installed."
+        echo "-------  Consider only specifying the dependencies/versions in the Pipfile."
+    fi
+  fi
+
   if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" || "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
 
     if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
-        echo "WARNING: Detected Pipfile and/or requirements file and Sceptre plugins"
-        echo "-------  Consider only specifying the Sceptre plugins in either file"
+        echo "WARNING: Detected Pipfile and/or requirements file and Sceptre plugins."
+        echo "-------  Consider only specifying the Sceptre plugins in either file."
     fi
 
-    if [[ "${sceptreTroposphere}" == 1 ]]; then
-      echo "WARNING: Detected Pipfile and/or requirements file and Troposhere version"
-      echo "-------  Consider only specifying the Troposphere version in either file"
+    if [[ "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" ]]; then
+      echo "WARNING: Detected Pipfile and/or requirements file and Troposhere version."
+      echo "-------  Consider only specifying the Troposphere version in either file."
     fi
 
     if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
-      echo "WARNING: Detected Pipfile and/or requirements file and a Sceptre version"
-      echo "-------  Consider only specifying the Sceptre version in the Pipfile"
+      echo "WARNING: Detected Pipfile and/or requirements file and a Sceptre version."
+      echo "-------  Consider only specifying the Sceptre version in the Pipfile."
     fi
 
   fi
 }
 
 function installDeps {
-  cd ${GITHUB_WORKSPACE}
 
   if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
     echo "Installing Pipenv"
-    pip install pipenv
+    if [[ "${INPUT_SCEPTRE_PIPENV_VERSION}" != "" ]]; then
+      pip install --no-input pipenv==$INPUT_SCEPTRE_PIPENV_VERSION
+    else
+      pip install --no-input pipenv
+    fi
     echo "Installing Python Pipfile"
-    cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install
-    pipenv shell
-    cd ${GITHUB_WORKSPACE}
+    (cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install)
   fi
 
   if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
@@ -104,12 +120,12 @@ function installDeps {
     pip install --no-input ${INPUT_SCEPTRE_PLUGINS}
   fi
 
-  if [[ "${sceptreTroposphere}" == 1 ]]; then
+  if [[ "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" ]]; then
     echo "Installing Troposphere version $sceptreTroposphereVer"
     pip install --no-input troposphere==$sceptreTroposphereVer
   fi
 
-  if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]] || ! command -v sceptre &> /dev/null; then
+  if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
     echo "Installing Sceptre version $sceptreVer"
     pip install --no-input sceptre==$sceptreVer
   fi
@@ -121,7 +137,12 @@ function main {
   installDeps
 
   cd ${GITHUB_WORKSPACE}/${sceptreDir}
-  sceptre $sceptreSubcommand
+
+  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
+    pipenv run sceptre $sceptreSubcommand
+  else
+    sceptre $sceptreSubcommand
+  fi
 }
 
 main "${*}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,12 +64,21 @@ function installDeps {
     echo "Installing Troposphere"
     pip install --no-input troposphere==$sceptreTroposphereVer
   fi
-  echo "Installing Sceptre"
-  pip install --no-input sceptre==$sceptreVer
   if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
     echo "Installing Sceptre plugins"
     pip install --no-input ${INPUT_SCEPTRE_PLUGINS}
   fi
+  if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
+    echo "Installing Python requirements"
+    pip install --no-input --requirement ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_REQUIREMENTS}
+  fi
+  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
+    echo "Installing Python Pipfile"
+    pip install pipenv
+    (cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install)
+  fi
+  echo "Installing Sceptre"
+  pip install --no-input sceptre==$sceptreVer
 }
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ function parseInputs {
   fi
 
   # Optional inputs
-  sceptreVer='2.3.0'
+  sceptreVer='2.5.0'
   if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
     if [[ "${INPUT_SCEPTRE_VERSION}" =~ ^2[.][0-9][.][0-9]$ ]]; then
       sceptreVer=${INPUT_SCEPTRE_VERSION}
@@ -57,28 +57,62 @@ function parseInputs {
     exit 1
   fi
 
+  if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" && "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
+    echo "WARNING: Detected Pipfile and requirements file"
+    echo "-------  Consider only specifying Python dependencies in one or the other"
+  fi
+
+  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" || "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
+
+    if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
+        echo "WARNING: Detected Pipfile and/or requirements file and Sceptre plugins"
+        echo "-------  Consider only specifying the Sceptre plugins in either file"
+    fi
+
+    if [[ "${sceptreTroposphere}" == 1 ]]; then
+      echo "WARNING: Detected Pipfile and/or requirements file and Troposhere version"
+      echo "-------  Consider only specifying the Troposphere version in either file"
+    fi
+
+    if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
+      echo "WARNING: Detected Pipfile and/or requirements file and a Sceptre version"
+      echo "-------  Consider only specifying the Sceptre version in the Pipfile"
+    fi
+
+  fi
 }
 
 function installDeps {
-  if [[ "${sceptreTroposphere}" == 1 ]]; then
-    echo "Installing Troposphere"
-    pip install --no-input troposphere==$sceptreTroposphereVer
+  cd ${GITHUB_WORKSPACE}
+
+  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
+    echo "Installing Pipenv"
+    pip install pipenv
+    echo "Installing Python Pipfile"
+    cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install
+    pipenv shell
+    cd ${GITHUB_WORKSPACE}
   fi
-  if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
-    echo "Installing Sceptre plugins"
-    pip install --no-input ${INPUT_SCEPTRE_PLUGINS}
-  fi
+
   if [[ "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
     echo "Installing Python requirements"
     pip install --no-input --requirement ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_REQUIREMENTS}
   fi
-  if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" ]]; then
-    echo "Installing Python Pipfile"
-    pip install pipenv
-    (cd $(dirname ${GITHUB_WORKSPACE}/${INPUT_SCEPTRE_PIPFILE}) && pipenv install)
+
+  if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
+    echo "Installing Sceptre plugins"
+    pip install --no-input ${INPUT_SCEPTRE_PLUGINS}
   fi
-  echo "Installing Sceptre"
-  pip install --no-input sceptre==$sceptreVer
+
+  if [[ "${sceptreTroposphere}" == 1 ]]; then
+    echo "Installing Troposphere version $sceptreTroposphereVer"
+    pip install --no-input troposphere==$sceptreTroposphereVer
+  fi
+
+  if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]] || ! command -v sceptre &> /dev/null; then
+    echo "Installing Sceptre version $sceptreVer"
+    pip install --no-input sceptre==$sceptreVer
+  fi
 }
 
 
@@ -87,7 +121,6 @@ function main {
   installDeps
 
   cd ${GITHUB_WORKSPACE}/${sceptreDir}
-
   sceptre $sceptreSubcommand
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@ function parseInputs {
       echo "ERROR: Input sceptre_version cannot be empty!"
       exit 1
     else
-      echo "WARNING: Sceptre version not specified, so it's assumed that it"
-      echo "-------  is specified in the Pipfile or requirements file."
+      echo "WARNING: Sceptre version not specified, so the assumumption is that the"
+      echo "         version is specified in the Pipfile or requirements file."
     fi
   fi
 
@@ -67,25 +67,25 @@ function parseInputs {
           || "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" \
           || "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
     echo "WARNING: Detected Pipfile and at least one other method for specifying"
-    echo "-------  dependencies/versions. Only the Pipfile will be installed."
-    echo "-------  Consider only specifying the dependencies/versions in the Pipfile."
+    echo "         dependencies/versions. Only the Pipfile will be installed."
+    echo "         Consider only specifying the dependencies/versions in the Pipfile."
   fi
 
   if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" || "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then
 
     if [[ "${INPUT_SCEPTRE_PLUGINS}" != "" ]]; then
         echo "WARNING: Detected Pipfile and/or requirements file and Sceptre plugins."
-        echo "-------  Consider only specifying the Sceptre plugins in either file."
+        echo "         Consider only specifying the Sceptre plugins in either file."
     fi
 
     if [[ "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" ]]; then
       echo "WARNING: Detected Pipfile and/or requirements file and Troposhere version."
-      echo "-------  Consider only specifying the Troposphere version in either file."
+      echo "         Consider only specifying the Troposphere version in either file."
     fi
 
     if [[ "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
       echo "WARNING: Detected Pipfile and/or requirements file and a Sceptre version."
-      echo "-------  Consider only specifying the Sceptre version in the Pipfile."
+      echo "         Consider only specifying the Sceptre version in the Pipfile."
     fi
 
   fi
@@ -139,7 +139,7 @@ function main {
   cd ${GITHUB_WORKSPACE}/${sceptreDir}
 
   $sceptreCommandPrefix $sceptreSubcommand
-  
+
 }
 
 main "${*}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,10 +71,9 @@ function parseInputs {
           || "${INPUT_SCEPTRE_PLUGINS}" != "" \
           || "${INPUT_SCEPTRE_TROPOSPHERE_VERSION}" != "" \
           || "${INPUT_SCEPTRE_VERSION}" != "" ]]; then
-        echo "WARNING: Detected Pipfile and at least one other method for specifying"
-        echo "-------  dependencies/versions. Only the Pipfile will be installed."
-        echo "-------  Consider only specifying the dependencies/versions in the Pipfile."
-    fi
+    echo "WARNING: Detected Pipfile and at least one other method for specifying"
+    echo "-------  dependencies/versions. Only the Pipfile will be installed."
+    echo "-------  Consider only specifying the dependencies/versions in the Pipfile."
   fi
 
   if [[ "${INPUT_SCEPTRE_PIPFILE}" != "" || "${INPUT_SCEPTRE_REQUIREMENTS}" != "" ]]; then


### PR DESCRIPTION
I tested the following permutations of the parameters [here](https://github.com/BrunoGrandePhD/aws-workflows-nextflow-infra/runs/2974458396?check_suite_focus=true) using this [test CI workflow](https://github.com/BrunoGrandePhD/aws-workflows-nextflow-infra/blob/bgande/test-sceptre-plugins/.github/workflows/aws-deploy.yaml). 

- Test Pipfile only
- Test requirements file only
- Test plugins only
- Test Troposphere and Sceptre version only
- Test everything with Pipfile
- Test everything without Pipfile
- Test everything without Pipfile and versions